### PR TITLE
chore: 📝 Fix typo in User Secrets documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Similar to the debugger, the plugin exposes the function `require("csharp").run_
 
 ### View & Edit User Secrets
 
-You can use the `require("csharp").view_user_secrets()` to view and edit [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets]
+You can use the `require("csharp").view_user_secrets()` to view and edit [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets).
 Similar to the debugger, the plugin exposes the function `require("csharp").run_project()` that supports selection of an executable project, launch profile, builds and runs the project.
 
 <hr>


### PR DESCRIPTION
Just a small correction in the README file.