### PR TITLE
bugfix(#4): correctly handling file:close

### DIFF
--- a/lua/csharp/modules/dotnet-cli.lua
+++ b/lua/csharp/modules/dotnet-cli.lua
@@ -4,8 +4,9 @@ local logger = require("csharp.log")
 local function execute_command(cmd)
   local file = io.popen(cmd .. " 2>&1")
   local output = file:read("*all")
-  local _, _, exit_code = file:close()
-  return output, exit_code
+
+  local success, _, exit_code = file:close()
+  return output, success and 0 or exit_code
 end
 
 --- @param target string File path to solution or project


### PR DESCRIPTION
it's basically a fix based on the answer of "[b3b00](https://github.com/b3b00)".

file:close doesn't always returns three values. This is only the case, when file:close returns false.

It now actually starts on my end.