### PR TITLE
Fix omnisharp config spontaneously combusting

### DIFF
--- a/lua/csharp/config.lua
+++ b/lua/csharp/config.lua
@@ -114,8 +114,9 @@ function M.set_defaults(user_config)
   }
 
   for index, key in ipairs(deprecated_omnisharp_keys) do
-    if merged_config.lsp.omnisharp[key] ~= nil then
-      merged_config.lsp.omnisharp[key] = nil
+    if merged_config.lsp[key] ~= nil then
+      merged_config.lsp[key] = nil
+      require("csharp.log").error("Use of deprecated key 'lsp."..key.."'. Use 'lsp.omnisharp."..key.."' instead.")
     end
   end
 

--- a/lua/csharp/log.lua
+++ b/lua/csharp/log.lua
@@ -1,35 +1,12 @@
+local queue = {}
 local M = {}
 
-function M.setup()
-  local ok, structlog = pcall(require, "structlog")
-
-  if not ok then
-    vim.notify("csharp.nvim: structlog.nvim dependency is not installed. This won't prevent the plugin from working, but it's recommended to install it.", vim.log.levels.WARN)
-    return
-  end
-
-  structlog.configure({
-    csharp_logger = {
-      pipelines = {
-        {
-          level = structlog.level.TRACE,
-          processors = {
-            structlog.processors.StackWriter({ "line", "file" }, { max_parents = 3 }),
-            structlog.processors.Timestamper("%H:%M:%S"),
-            function(log)
-              log["buffer"] = vim.api.nvim_get_current_buf()
-              return log
-            end,
-          },
-          formatter = structlog.formatters.Format( --
-            "%s [%s] %s: %-30s buffer=%s",
-            { "timestamp", "level", "logger_name", "msg", "buffer" }
-          ),
-          sink = structlog.sinks.File(vim.fn.stdpath("log") .. "/csharp.log"),
-        },
-      },
-    },
-  })
+---Queue a log message until logging is initialized
+---@param level string
+---@param message string
+---@param data table?
+function M.queue(level, message, data)
+  table.insert(queue, {level = level, message = message, data = data})
 end
 
 ---@param level string
@@ -37,6 +14,9 @@ end
 ---@param data table?
 function M.log(level, message, data)
   local config = require("csharp.config").get_config().logging
+  if config == nil then
+    M.queue(level, message, data)
+  end
   local logger = require("structlog").get_logger("csharp_logger")
   if logger == nil or vim.log.levels[level] < vim.log.levels[config.level] then
     return
@@ -74,4 +54,41 @@ end
 function M.error(message, data)
   M.log("ERROR", message, data)
 end
+
+function M.setup()
+  local ok, structlog = pcall(require, "structlog")
+
+  if not ok then
+    vim.notify("csharp.nvim: structlog.nvim dependency is not installed. This won't prevent the plugin from working, but it's recommended to install it.", vim.log.levels.WARN)
+    return
+  end
+
+  structlog.configure({
+    csharp_logger = {
+      pipelines = {
+        {
+          level = structlog.level.TRACE,
+          processors = {
+            structlog.processors.StackWriter({ "line", "file" }, { max_parents = 3 }),
+            structlog.processors.Timestamper("%H:%M:%S"),
+            function(log)
+              log["buffer"] = vim.api.nvim_get_current_buf()
+              return log
+            end,
+          },
+          formatter = structlog.formatters.Format( --
+            "%s [%s] %s: %-30s buffer=%s",
+            { "timestamp", "level", "logger_name", "msg", "buffer" }
+          ),
+          sink = structlog.sinks.File(vim.fn.stdpath("log") .. "/csharp.log"),
+        },
+      },
+    },
+  })
+
+  for _, msg in pairs(queue) do 
+    M.log(msg.level, msg.message, msg.data)
+  end
+end
+
 return M

--- a/lua/csharp/log.lua
+++ b/lua/csharp/log.lua
@@ -13,10 +13,11 @@ end
 ---@param message string
 ---@param data table?
 function M.log(level, message, data)
-  local config = require("csharp.config").get_config().logging
+  local config = require("csharp.config").get_config()
   if config == nil then
     M.queue(level, message, data)
   end
+  config = config.logging
   local logger = require("structlog").get_logger("csharp_logger")
   if logger == nil or vim.log.levels[level] < vim.log.levels[config.level] then
     return

--- a/lua/csharp/log.lua
+++ b/lua/csharp/log.lua
@@ -16,6 +16,7 @@ function M.log(level, message, data)
   local config = require("csharp.config").get_config()
   if config == nil then
     M.queue(level, message, data)
+    return
   end
   config = config.logging
   local logger = require("structlog").get_logger("csharp_logger")


### PR DESCRIPTION
When setup was called with a user config as an argument, most of the options in `lsp.omnisharp` would be set to nil due to a small mistake in the code. I also added a helpful log.