### PR TITLE
fix: commandLineArgs were incorrectly applied in debugger

### DIFF
--- a/lua/csharp/features/debugger/init.lua
+++ b/lua/csharp/features/debugger/init.lua
@@ -18,7 +18,7 @@ local function apply_launch_profile(debug_config, launch_profile)
 
   if launch_profile.commandLineArgs then
     local args = vim.split(launch_profile.commandLineArgs, " ", { trimempty = true })
-    for _, arg in args do
+    for _, arg in ipairs(args) do
       table.insert(debug_config.args, arg)
     end
   end

--- a/lua/csharp/features/debugger/init.lua
+++ b/lua/csharp/features/debugger/init.lua
@@ -17,7 +17,10 @@ local function apply_launch_profile(debug_config, launch_profile)
   end
 
   if launch_profile.commandLineArgs then
-    vim.tbl_deep_extend("force", debug_config.args, vim.split(launch_profile.commandLineArgs, " ", { trimempty = true }))
+    local args = vim.split(launch_profile.commandLineArgs, " ", { trimempty = true })
+    for _, arg in args do
+      table.insert(debug_config.args, arg)
+    end
   end
 
   if launch_profile.applicationUrl then


### PR DESCRIPTION
in my launch settings I had 
```json
"commandLineArgs": "--file TestLoop.txt",
```

this was working in run mode, but not in the debugger.

I found the issue:
the function vim.tbl_deep_extend did not seem to add the arguments correctly, whereas the table.insert does.
It looks like the urls section of the launch settings already works the same