### PR TITLE
fix: debugger not found on Windows

### DIFF
--- a/lua/csharp/features/user-secrets/init.lua
+++ b/lua/csharp/features/user-secrets/init.lua
@@ -8,7 +8,7 @@ local _lua_pattern_guid = "%w+-%w+-%w+-%w+-%w+"
 -- Creates the user secret file if the same
 -- doesn't exists
 local function _ensure_secret_exists(user_secret_folder_path)
-  local full_file_path = user_secret_folder_path .. "/secrets.json"
+  local full_file_path = utils.join_paths(user_secret_folder_path, "secrets.json")
   local file, _ = io.open(full_file_path, "r+")
 
   if not file then

--- a/lua/csharp/modules/dap.lua
+++ b/lua/csharp/modules/dap.lua
@@ -23,13 +23,12 @@ function M.get_debug_adapter()
     package:install()
   end
 
-  local exec_path = {package:get_install_path(), "netcoredbg"}
+  local path = utils.join_paths(package:get_install_path(), "netcoredbg")
+
   -- Netcoredbg puts the executable in a different spot
   if vim.loop.os_uname().sysname == "Windows_NT" then
-    exec_path[#exec_path+1] = "netcoredbg.exe"
+    path = utils.join_paths(path, "netcoredbg.exe")
   end
-
-  local path = utils.join_paths(table.unpack(exec_path))
 
   dap.adapters.coreclr = {
     type = "executable",

--- a/lua/csharp/modules/dap.lua
+++ b/lua/csharp/modules/dap.lua
@@ -29,7 +29,7 @@ function M.get_debug_adapter()
     exec_path[#exec_path+1] = "netcoredbg.exe"
   end
   
-  local path = utils.join_paths(package:get_install_path(), "netcoredbg")
+  local path = utils.join_paths(package:get_install_path(), exec_path)
 
   dap.adapters.coreclr = {
     type = "executable",

--- a/lua/csharp/modules/dap.lua
+++ b/lua/csharp/modules/dap.lua
@@ -1,6 +1,7 @@
 local M = {}
 local config_store = require("csharp.config")
 local dap = require("dap")
+local utils = require("csharp.utils")
 
 function M.get_debug_adapter()
   local config = config_store.get_config().dap
@@ -22,7 +23,7 @@ function M.get_debug_adapter()
     package:install()
   end
 
-  local path = package:get_install_path() .. "/netcoredbg"
+  local path = utils.join_paths(package:get_install_path(), "netcoredbg")
 
   dap.adapters.coreclr = {
     type = "executable",

--- a/lua/csharp/modules/dap.lua
+++ b/lua/csharp/modules/dap.lua
@@ -23,6 +23,12 @@ function M.get_debug_adapter()
     package:install()
   end
 
+  -- Netcoredbg puts the executable in a different spot
+  local exec_path = {"netcoredbg"}
+  if vim.loop.os_uname().sysname == "Windows_NT" then
+    exec_path[#exec_path+1] = "netcoredbg.exe"
+  end
+  
   local path = utils.join_paths(package:get_install_path(), "netcoredbg")
 
   dap.adapters.coreclr = {

--- a/lua/csharp/modules/dap.lua
+++ b/lua/csharp/modules/dap.lua
@@ -23,13 +23,13 @@ function M.get_debug_adapter()
     package:install()
   end
 
+  local exec_path = {package:get_install_path(), "netcoredbg"}
   -- Netcoredbg puts the executable in a different spot
-  local exec_path = {"netcoredbg"}
   if vim.loop.os_uname().sysname == "Windows_NT" then
     exec_path[#exec_path+1] = "netcoredbg.exe"
   end
-  
-  local path = utils.join_paths(package:get_install_path(), exec_path)
+
+  local path = utils.join_paths(table.unpack(exec_path))
 
   dap.adapters.coreclr = {
     type = "executable",

--- a/lua/csharp/modules/launch-settings.lua
+++ b/lua/csharp/modules/launch-settings.lua
@@ -1,6 +1,7 @@
 local M = {}
 local logger = require("csharp.log")
 local ui = require("csharp.ui")
+local utils = require("csharp.utils")
 
 --- @class DotNetLaunchProfile
 --- @field name string
@@ -32,7 +33,7 @@ end
 --- @param project_folder string
 --- @return DotNetLaunchProfile[]
 local function get_launch_profiles(project_folder)
-  local file_name = project_folder .. "/Properties/launchSettings.json"
+  local file_name = utils.join_paths(project_folder, "Properties", "launchSettings.json")
   local launch_settings = readFileWithoutBom(file_name)
 
   if launch_settings == nil then

--- a/lua/csharp/modules/lsp/omnisharp.lua
+++ b/lua/csharp/modules/lsp/omnisharp.lua
@@ -1,5 +1,6 @@
 local M = {}
 local config_store = require("csharp.config")
+local utils = require("csharp.utils")
 
 --- @return string
 --- @param buffer number
@@ -34,7 +35,7 @@ local function get_omnisharp_cmd()
     package:install()
   end
 
-  return package:get_install_path() .. "/omnisharp"
+  return utils.join_paths(package:get_install_path(), "omnisharp")
 end
 
 local function start_omnisharp(buffer)

--- a/lua/csharp/utils.lua
+++ b/lua/csharp/utils.lua
@@ -48,4 +48,12 @@ function M.run_async(fn)
   end
 end
 
+--- @param paths to join
+--- @return string with combined paths
+function M.join_paths(...)
+  local separator = package.config:sub(1, 1)
+  local paths = {...}
+  return table.concat(paths, separator)
+end
+
 return M

--- a/lua/csharp/utils.lua
+++ b/lua/csharp/utils.lua
@@ -51,7 +51,7 @@ end
 --- @param paths to join
 --- @return string with combined paths
 function M.join_paths(...)
-  local separator = package.config:sub(1, 1)
+  local separator = "/"
   local paths = {...}
   return table.concat(paths, separator)
 end

--- a/lua/csharp/utils.lua
+++ b/lua/csharp/utils.lua
@@ -51,7 +51,7 @@ end
 --- @param paths to join
 --- @return string with combined paths
 function M.join_paths(...)
-  local separator = "/"
+  local separator = package.config:sub(1, 1)
   local paths = {...}
   return table.concat(paths, separator)
 end

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -101,3 +101,24 @@ describe("omnisharp_text_changes_to_text_edits", function()
     assert.are.same(expected, result)
   end)
 end)
+
+describe("join_paths", function()
+  local test_cases = {
+    { sep = "/",  input = {"home", "user", "docs"},  expected = "home/user/docs",  desc = "Linux-style" },
+    { sep = "\\", input = {"C:", "Users", "User"},   expected = "C:\\Users\\User", desc = "Windows-style" },
+    { sep = "/",  input = {"var", "log", "app"},    expected = "var/log/app",     desc = "Another Linux" }
+  }
+
+  for _, case in ipairs(test_cases) do
+      it("should join the paths in: " .. case.desc, function()
+          local original_config = package.config
+          package.config = case.sep .. "\n"
+
+          local result = utils.join_paths(table.unpack(case.input))
+          
+          assert.are.equal(case.expected, result)
+
+          package.config = original_config
+      end)
+  end
+end)


### PR DESCRIPTION
Closes #26. This PR fixes the issue of the debugger not being found on Windows, as the path for the netcoredbg debugger executable is in a different spot. 