### PR TITLE
bugfix: avoid usage of removed package:get_package_path()

### DIFF
--- a/lua/csharp/modules/lsp/omnisharp.lua
+++ b/lua/csharp/modules/lsp/omnisharp.lua
@@ -34,7 +34,7 @@ local function get_omnisharp_cmd()
     package:install()
   end
 
-  return package:get_install_path() .. "/omnisharp"
+  return vim.fn.expand("$MASON/packages/omnisharp/omnisharp")
 end
 
 local function start_omnisharp(buffer)


### PR DESCRIPTION
This change fixes error on csharp nvim lsp startup, by using the old $MASON environment variable.

Please merge this ASAP - the removed api is causing startup errors.

https://github.com/mason-org/mason.nvim/discussions/33#discussioncomment-13095400

> > @ Alan-John-Byrne
> > > Sadly this no longer works. The get_install_path method was completely removed.
> > 
> > 
> > I had the same problem, there is a changelog note: https://github.com/mason-org/mason.nvim/blob/7c7318e8bae7e3536ef6b9e86b9e38e74f2e125e/CHANGELOG.md?plain=1#L65
> > 
> > I'm using `vim.fn.expand "$MASON/packages/codelldb"` for example.
> 
> Thanks for the heads up 👍
